### PR TITLE
display Text instead of URL on sidebar

### DIFF
--- a/src/ExternalLinksComponent.tsx
+++ b/src/ExternalLinksComponent.tsx
@@ -55,7 +55,7 @@ export const ExternalLinksComponent = (props: ExternalLinksViewProps) => {
 					<div key={nodeId} className="tree-item-self">
 						<Link2 className="tree-item-icon"/>
 						<div className="tree-item-content">
-							<a className="tree-item-inner" href={el.Url}>{el.Url}</a>
+							<a className="tree-item-inner" href={el.Url}>{el.Text}</a>
 							{refList(nodeId, urlToFiles.get(el.Url), activeFile)}
 						</div>
 					</div>


### PR DESCRIPTION
Display text instead of raw URL on sidebar; I believe it is the desired behavior. like this:

<img width="262" alt="image" src="https://github.com/jivimberg/external-links/assets/149959021/6cbef915-a551-4014-83b9-88a576cbe4d9">
