### PR TITLE
Fix sidebar loading (Obsidian v1.7.2 compatibility)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5524,10 +5524,11 @@
 			}
 		},
 		"node_modules/obsidian": {
-			"version": "1.5.7-1",
-			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.5.7-1.tgz",
-			"integrity": "sha512-T5ZRuQ1FnfXqEoakTTHVDYvzUEEoT8zSPnQCW31PVgYwG4D4tZCQfKHN2hTz1ifnCe8upvwa6mBTAP2WUA5Vng==",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.7.2.tgz",
+			"integrity": "sha512-k9hN9brdknJC+afKr5FQzDRuEFGDKbDjfCazJwpgibwCAoZNYHYV8p/s3mM8I6AsnKrPKNXf8xGuMZ4enWelZQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/codemirror": "5.60.8",
 				"moment": "2.29.4"

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,33 +18,20 @@ export default class ExternalLinksPlugin extends Plugin {
 			(leaf) => new ExternalLinksView(leaf, this)
 		);
 
-		await this.activateView();
+		this.addCommand({
+			id: 'show-external-links',
+			name: 'Show external links',
+			callback: () => {
+				this.activateView();
+			},
+		});
 	}
 
-	onunload() {
-
+	onUserEnable() {
+		this.activateView();
 	}
 
 	async activateView() {
-		const { workspace } = this.app;
-
-		let leaf: WorkspaceLeaf | null = null;
-		const leaves = workspace.getLeavesOfType(VIEW_TYPE_EXTERNAL_LINK_VIEW);
-
-		if (leaves.length > 0) {
-			// A leaf with our view already exists, use that
-			leaf = leaves[0];
-		} else {
-			// Our view could not be found in the workspace, create a new leaf
-			// in the right sidebar for it
-			leaf = workspace.getRightLeaf(false);
-			await leaf?.setViewState({ type: VIEW_TYPE_EXTERNAL_LINK_VIEW, active: true });
-		}
-
-		// "Reveal" the leaf in case it is in a collapsed sidebar
-		if (leaf) {
-			workspace.revealLeaf(leaf);
-		}
+		await this.app.workspace.ensureSideLeaf(VIEW_TYPE_EXTERNAL_LINK_VIEW, 'right');
 	}
-
 }


### PR DESCRIPTION
Fix for comaptibility with Obsidian v1.7.2.

Use `ensureSideLeaf` to open the sidebar view (made public in obsidian API v1.7.2, but existed before), instead of opening it every time the plugin is loaded. This prevents the plugin from stealing focus every time obsidian is opened.

The sidebar view is now only added when the user explicitly enables the plugin. To account for the change, a command to explicitly open the view was also added. This matches the behavior of the core Outgoing links and Backlinks plugins.